### PR TITLE
API-2298 Add withDetailLevel to ApiClient.Builder

### DIFF
--- a/resources/sdk/purecloudjava/templates/ApiClient.mustache
+++ b/resources/sdk/purecloudjava/templates/ApiClient.mustache
@@ -682,6 +682,11 @@ public class ApiClient implements Closeable {
             return this;
         }
 
+        public Builder withDetailLevel(SLF4JInterceptor.DetailLevel detailLevel) {
+            this.detailLevel = detailLevel;
+            return this;
+        }
+
         public ApiClient build() {
             return new ApiClient(this);
         }


### PR DESCRIPTION
Adds missing `withDetailLevel` method to `ApiClient.Builder`.